### PR TITLE
feat: add shippoAccountId request option

### DIFF
--- a/src/lib/sdks.ts
+++ b/src/lib/sdks.ts
@@ -53,6 +53,13 @@ export type RequestOptions = {
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options|Request}
    */
   fetchOptions?: Omit<RequestInit, "method" | "body">;
+  /**
+   * The Shippo Account ID to scope this request to.
+   * When using a Platform Account, set this to make API calls on behalf of a customer.
+   * Sent as the `SHIPPO-ACCOUNT-ID: <ShippoAccountID>` header.
+   */
+  shippoAccountId?: string;
+
 } & Omit<RequestInit, "method" | "body">;
 
 type RequestConfig = {
@@ -159,6 +166,10 @@ export class ClientSDK {
         [username || "", password || ""].join(":"),
       );
       headers.set("Authorization", `Basic ${encoded}`);
+    }
+
+    if (options?.shippoAccountId) {
+      headers.set("SHIPPO-ACCOUNT-ID", options.shippoAccountId);
     }
 
     const securityHeaders = new Headers(security?.headers || {});


### PR DESCRIPTION
## Summary
- Add `shippoAccountId?: string` to `RequestOptions` in `src/lib/sdks.ts`.
- Set the `SHIPPO-ACCOUNT-ID` request header when `options.shippoAccountId` is provided.
- Document Platform Account usage for customer-scoped API calls in JSDoc.

## Why
Platform Account workflows require passing `SHIPPO-ACCOUNT-ID: <ShippoAccountID>` to make API calls on behalf of a customer account.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core request construction for all SDK calls by conditionally injecting a new `SHIPPO-ACCOUNT-ID` header, which could affect request behavior if misused or if headers collide. Otherwise the change is small and backward-compatible (new optional field).
> 
> **Overview**
> Adds an optional `shippoAccountId` to `RequestOptions` and documents its Platform Account use.
> 
> When provided, the client now includes `SHIPPO-ACCOUNT-ID: <id>` on outgoing requests during request creation, enabling customer-scoped API calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 806f17c59112895939a61556dc7c76e175611f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->