### PR TITLE
docs(SECT-1386): use API token placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To use the API, you must generate an [API Token](https://docs.goshippo.com/docs/
 
 For example.
 ```
-api_key_header="shippo_test_595d9cb0c0e14497bf07e75ecfec6c6d"
+api_key_header="<YOUR_API_TOKEN>"
 ```
 
 


### PR DESCRIPTION
## Summary
- Use `<YOUR_API_TOKEN>` instead of a literal token in the README example.

## Jira Ticket
https://shippo.atlassian.net/browse/SECT-1386

## Test Plan
- [x] Confirm the README example uses the placeholder.
- [x] Confirm the matching literal is absent from the current tree.

Made with [Cursor](https://cursor.com)